### PR TITLE
Rename Object into ZuoraObject to support PHP 7.2

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,3 @@
 # for php-coveralls
 service_name: travis-ci
-src_dir: src
 coverage_clover: build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
   - composer install --prefer-dist --dev
 
 after_script:
-  - php vendor/bin/coveralls -v
+  - php vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - "5.5"
-  - "5.4"
-  - "5.3"
+  - "7.1"
+  - "7.2"
+  - "7.3"
 
 before_script:
   - composer install --prefer-dist --dev

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         "issues": "https://github.com/mhrabovcin/zuora-rest/issues"
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": "^7.1"
     },
     "require-dev": {
         "pdepend/pdepend": "~1.0",
-        "phploc/phploc": "~2.0",
         "phpmd/phpmd": "~1.0",
-        "phpunit/phpunit": "~3.0",
         "satooshi/php-coveralls": "*",
-        "sebastian/phpcpd": "~2.0"
+        "sebastian/phpcpd": "~2.0",
+        "phpunit/phpunit": "^7.5",
+        "phploc/phploc": "^4.0"
     },
     "autoload": {
         "psr-0": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="test/bootstrap.php">
 
     <testsuites>
@@ -22,9 +21,9 @@
     </filter>
 
     <logging>
-      <log type="coverage-html" target="build/coverage" charset="UTF-8"/>
-      <log type="coverage-clover" target="build/logs/clover.xml" charset="UTF-8"/>
-      <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+      <log type="coverage-html" target="build/coverage"/>
+      <log type="coverage-clover" target="build/logs/clover.xml"/>
+      <log type="junit" target="build/logs/junit.xml"/>
     </logging>
 
 </phpunit>

--- a/src/Zuora/Environment.php
+++ b/src/Zuora/Environment.php
@@ -2,8 +2,8 @@
 
 namespace Zuora;
 
-class Environment {
-
+class Environment
+{
     /**
      * Endpoint URL.
      *
@@ -31,7 +31,7 @@ class Environment {
     protected $password;
 
     /**
-     * Create new environemnt.
+     * Create new environment.
      *
      * @param array $options
      *   array(
@@ -43,7 +43,8 @@ class Environment {
      *
      * @return Environment
      */
-    public static function factory($options) {
+    public static function factory($options)
+    {
         $environment = new static();
 
         if (isset($options['endpoint'])) {
@@ -140,5 +141,4 @@ class Environment {
     {
         return $this->getEndpoint() . '/v' . $this->getVersion() . '/' . $path;
     }
-
-} 
+}

--- a/src/Zuora/Exception/ApiException.php
+++ b/src/Zuora/Exception/ApiException.php
@@ -25,7 +25,7 @@ class ApiException extends ResponseException {
      */
     public function getReasons()
     {
-        $object = new \Zuora\Object\Object($this->getData());
+        $object = new \Zuora\Object\ZuoraObject($this->getData());
         return $object->map('reasons', '\Zuora\Object\Reason');
     }
 

--- a/src/Zuora/Exception/ApiException.php
+++ b/src/Zuora/Exception/ApiException.php
@@ -2,9 +2,8 @@
 
 namespace Zuora\Exception;
 
-
-class ApiException extends ResponseException {
-
+class ApiException extends ResponseException
+{
 
     /**
      * Retrieve Zuora Process ID
@@ -17,7 +16,6 @@ class ApiException extends ResponseException {
         return isset($data['processId']) ? $data['processId'] : null;
     }
 
-
     /**
      * Return list of error reasons
      *
@@ -28,7 +26,6 @@ class ApiException extends ResponseException {
         $object = new \Zuora\Object\ZuoraObject($this->getData());
         return $object->map('reasons', '\Zuora\Object\Reason');
     }
-
 
     /**
      * Create single line message from exception.
@@ -49,5 +46,4 @@ class ApiException extends ResponseException {
 
         return $output;
     }
-
-} 
+}

--- a/src/Zuora/Exception/Exception.php
+++ b/src/Zuora/Exception/Exception.php
@@ -2,7 +2,6 @@
 
 namespace Zuora\Exception;
 
-
 class Exception extends \Exception
 {
 

--- a/src/Zuora/Exception/ResponseException.php
+++ b/src/Zuora/Exception/ResponseException.php
@@ -2,11 +2,10 @@
 
 namespace Zuora\Exception;
 
-
 use Zuora\Http\Response;
 
-class ResponseException extends Exception {
-
+class ResponseException extends Exception
+{
 
     /**
      * Http response object.
@@ -21,7 +20,7 @@ class ResponseException extends Exception {
      *
      * @param Response $response
      */
-    function __construct(Response $response)
+    public function __construct(Response $response)
     {
         $this->response = $response;
         parent::__construct($this->getMessageFromResponse());
@@ -43,7 +42,7 @@ class ResponseException extends Exception {
     public function getMessageFromResponse()
     {
         $response = $this->getResponse();
-        $message = array();
+        $message = [];
 
         if ($response->getCode()) {
             $message[] = $response->getCode();
@@ -70,13 +69,14 @@ class ResponseException extends Exception {
         return $this->getResponse()->getData();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function __toString()
     {
         if ($message = $this->getMessageFromResponse()) {
             return $message;
         }
-        else {
-            return parent::__toString();
-        }
+        return parent::__toString();
     }
 }

--- a/src/Zuora/Http/Request.php
+++ b/src/Zuora/Http/Request.php
@@ -4,7 +4,6 @@
 
 namespace Zuora\Http;
 
-
 class Request implements RequestInterface
 {
 
@@ -24,17 +23,17 @@ class Request implements RequestInterface
      *   - ssl_verifypeer_skip : Skip ssl verification
      *   - user_agent : Override user-agent name
      */
-    function __construct($curl_options = array())
+    public function __construct($curl_options = [])
     {
         // Add default options
-        $this->curl_options = $curl_options + array(
+        $this->curl_options = $curl_options + [
             'timeout' => 5,
             'ssl_verifypeer_skip' => false,
             'user_agent' => 'Zuora PHP Client/0.1',
             // Default SSL version is TLS v1.2. For PHP 5.5+ you may
             // use CURL constants as CURL_SSLVERSION_TLSv1_2
             'ssl_version' => 6,
-        );
+        ];
     }
 
     /**
@@ -59,21 +58,20 @@ class Request implements RequestInterface
      *
      * @return Response
      */
-    public function call($url, $method = 'GET', $query = array(), $data = array(), $headers = array(), $files = array())
+    public function call($url, $method = 'GET', $query = [], $data = [], $headers = [], $files = [])
     {
         // Normalize HTTP method name
         $method = $this->normalizeHttpMethod($method);
 
         // Zuora API talks in JSON
-        $headers += array(
+        $headers += [
             'Accept' => 'application/json',
-        );
+        ];
 
         // If sending files, app should be not json
         if (empty($files)) {
             $headers['Content-Type'] = 'application/json';
-        }
-        else {
+        } else {
             $files = array_map(function ($item) {
                 return '@' . $item;
             }, $files);
@@ -132,19 +130,19 @@ class Request implements RequestInterface
      * @return array
      *   cURL options
      */
-    protected function getCurlOptions($url, $port = null, $method = 'GET', $data = array(), $headers = array(), $files = array())
+    protected function getCurlOptions($url, $port = null, $method = 'GET', $data = [], $headers = [], $files = [])
     {
         // Default options for every CURL request
-        $opts = array(
+        $opts = [
             CURLOPT_URL => $url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT => $this->curl_options['timeout'],
-            CURLOPT_HTTPHEADER => array(),
+            CURLOPT_HTTPHEADER => [],
             CURLOPT_HEADER => true,
             CURLINFO_HEADER_OUT => true,
             CURLOPT_USERAGENT => $this->curl_options['user_agent'],
             CURLOPT_SSLVERSION => $this->curl_options['ssl_version'],
-        );
+        ];
 
         if (isset($port)) {
             $opts[CURLOPT_PORT] = $port;
@@ -152,8 +150,7 @@ class Request implements RequestInterface
 
         if (!empty($files)) {
             $opts[CURLOPT_POSTFIELDS] = $files + $data;
-        }
-        elseif (!empty($data) && $method != 'GET') {
+        } elseif (!empty($data) && $method != 'GET') {
             $opts[CURLOPT_POSTFIELDS] = json_encode($data);
         }
 
@@ -162,8 +159,7 @@ class Request implements RequestInterface
             if (!isset($opts[CURLOPT_POSTFIELDS]) || (isset($opts[CURLOPT_POSTFIELDS]) && !is_array($opts[CURLOPT_POSTFIELDS]))) {
                 $opts[CURLOPT_POST] = 1;
             }
-        }
-        elseif (in_array($method, array('DELETE', 'PUT'))) {
+        } elseif (in_array($method, ['DELETE', 'PUT'])) {
             $opts[CURLOPT_CUSTOMREQUEST] = $method;
         }
 
@@ -205,7 +201,7 @@ class Request implements RequestInterface
      * @return array
      *   Array where 0 key is normalized URL and 1 is port if was specified in URL
      */
-    protected function normalizeUrl($url, $query = array())
+    protected function normalizeUrl($url, $query = [])
     {
         // URL can contain port, make sure its processed correctly.
         $parsed_url = parse_url($url);
@@ -227,6 +223,6 @@ class Request implements RequestInterface
             $url .= http_build_query($query, null, '&');
         }
 
-        return array($url, isset($parsed_url['port']) ? $parsed_url['port'] : NULL);
+        return [$url, isset($parsed_url['port']) ? $parsed_url['port'] : null];
     }
 }

--- a/src/Zuora/Http/RequestInterface.php
+++ b/src/Zuora/Http/RequestInterface.php
@@ -1,15 +1,9 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: mhrabovcin
- * Date: 09/05/14
- * Time: 15:51
- */
 
 namespace Zuora\Http;
 
-
-interface RequestInterface {
+interface RequestInterface
+{
 
     /**
      * Make HTTP Request via cURL
@@ -33,6 +27,5 @@ interface RequestInterface {
      *
      * @return Response
      */
-    public function call($url, $method = 'GET', $query = array(), $data = array(), $headers = array(), $files = array());
-
-} 
+    public function call($url, $method = 'GET', $query = [], $data = [], $headers = [], $files = []);
+}

--- a/src/Zuora/Http/Response.php
+++ b/src/Zuora/Http/Response.php
@@ -2,7 +2,6 @@
 
 namespace Zuora\Http;
 
-
 class Response
 {
 
@@ -32,7 +31,7 @@ class Response
      *
      * @var array
      */
-    protected $headers = array();
+    protected $headers = [];
 
     /**
      * Error message
@@ -156,7 +155,7 @@ class Response
     public function getCookies()
     {
         if (!isset($this->cookies)) {
-            $this->cookies = array();
+            $this->cookies = [];
             foreach ($this->getHeaders() as $line) {
                 if (preg_match('~^Set-Cookie:\s* (?<name>[^=]+)=(?<value>[^;]+).*$~', $line, $matches)) {
                     $this->cookies[$matches['name']] = $matches['value'];
@@ -218,4 +217,4 @@ class Response
 
         return $response;
     }
-} 
+}

--- a/src/Zuora/Object/Account.php
+++ b/src/Zuora/Object/Account.php
@@ -2,10 +2,10 @@
 
 namespace Zuora\Object;
 
+class Account extends ZuoraObject
+{
 
-class Account extends ZuoraObject {
-
-    function __construct($data = array())
+    public function __construct($data = [])
     {
         $changed = $data['basicInfo'];
 
@@ -29,7 +29,7 @@ class Account extends ZuoraObject {
      */
     protected function getAllowedKeys()
     {
-        return array('billToContact', 'soldToContact');
+        return ['billToContact', 'soldToContact'];
     }
 
     /**
@@ -154,13 +154,11 @@ class Account extends ZuoraObject {
 
     public function getBillToContact()
     {
-        return new \Zuora\Object\Contact($this->billToContact);
+        return new Contact($this->billToContact);
     }
 
     public function getSoldToContact()
     {
-        return new \Zuora\Object\Contact($this->soldToContact);
+        return new Contact($this->soldToContact);
     }
-
-
-} 
+}

--- a/src/Zuora/Object/Account.php
+++ b/src/Zuora/Object/Account.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class Account extends Object {
+class Account extends ZuoraObject {
 
     function __construct($data = array())
     {

--- a/src/Zuora/Object/AccountSummary.php
+++ b/src/Zuora/Object/AccountSummary.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class AccountSummary extends Account {
+class AccountSummary extends Account
+{
 
     protected function getAllowedKeys()
     {
@@ -30,8 +30,8 @@ class AccountSummary extends Account {
         return $this->map('payments', '\Zuora\Object\PaymentSummary');
     }
 
-    public function getDefaultPaymentMethod() {
+    public function getDefaultPaymentMethod()
+    {
         return new DefaultPaymentMethod($this->defaultPaymentMethod);
     }
-
-} 
+}

--- a/src/Zuora/Object/Contact.php
+++ b/src/Zuora/Object/Contact.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class Contact extends Object {
+class Contact extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/Contact.php
+++ b/src/Zuora/Object/Contact.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class Contact extends ZuoraObject {
+class Contact extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -156,6 +156,4 @@ class Contact extends ZuoraObject {
     {
         return $this->zipCode;
     }
-
-
-} 
+}

--- a/src/Zuora/Object/CreditCard.php
+++ b/src/Zuora/Object/CreditCard.php
@@ -2,15 +2,15 @@
 
 namespace Zuora\Object;
 
-
-class CreditCard extends ZuoraObject {
+class CreditCard extends ZuoraObject
+{
 
     /**
      * @return mixed
      */
     public function getCardHolderInfo()
     {
-        return new \Zuora\Object\CreditCardHolder($this->cardHolderInfo);
+        return new CreditCardHolder($this->cardHolderInfo);
     }
 
     /**
@@ -60,5 +60,4 @@ class CreditCard extends ZuoraObject {
     {
         return $this->id;
     }
-
-} 
+}

--- a/src/Zuora/Object/CreditCard.php
+++ b/src/Zuora/Object/CreditCard.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class CreditCard extends Object {
+class CreditCard extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/CreditCardHolder.php
+++ b/src/Zuora/Object/CreditCardHolder.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class CreditCardHolder extends ZuoraObject {
+class CreditCardHolder extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -76,5 +76,4 @@ class CreditCardHolder extends ZuoraObject {
     {
         return $this->zipCode;
     }
-
-} 
+}

--- a/src/Zuora/Object/CreditCardHolder.php
+++ b/src/Zuora/Object/CreditCardHolder.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class CreditCardHolder extends Object {
+class CreditCardHolder extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/DefaultPaymentMethod.php
+++ b/src/Zuora/Object/DefaultPaymentMethod.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class DefaultPaymentMethod extends ZuoraObject {
+class DefaultPaymentMethod extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -52,4 +52,4 @@ class DefaultPaymentMethod extends ZuoraObject {
     {
         return $this->paymentMethodType;
     }
-} 
+}

--- a/src/Zuora/Object/DefaultPaymentMethod.php
+++ b/src/Zuora/Object/DefaultPaymentMethod.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class DefaultPaymentMethod extends Object {
+class DefaultPaymentMethod extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/HmacSignature.php
+++ b/src/Zuora/Object/HmacSignature.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class HmacSignature extends Object {
+class HmacSignature extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/HmacSignature.php
+++ b/src/Zuora/Object/HmacSignature.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class HmacSignature extends ZuoraObject {
+class HmacSignature extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -28,4 +28,4 @@ class HmacSignature extends ZuoraObject {
     {
         return $this->token;
     }
-} 
+}

--- a/src/Zuora/Object/ImportStatus.php
+++ b/src/Zuora/Object/ImportStatus.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class ImportStatus extends ZuoraObject {
+class ImportStatus extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -20,5 +20,4 @@ class ImportStatus extends ZuoraObject {
     {
         return $this->message;
     }
-
-} 
+}

--- a/src/Zuora/Object/ImportStatus.php
+++ b/src/Zuora/Object/ImportStatus.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class ImportStatus extends Object {
+class ImportStatus extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/Invoice.php
+++ b/src/Zuora/Object/Invoice.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class Invoice extends ZuoraObject {
+class Invoice extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -100,4 +100,4 @@ class Invoice extends ZuoraObject {
     {
         return $this->map('invoiceItems', '\Zuora\Object\InvoiceItem');
     }
-} 
+}

--- a/src/Zuora/Object/Invoice.php
+++ b/src/Zuora/Object/Invoice.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class Invoice extends Object {
+class Invoice extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/InvoiceItem.php
+++ b/src/Zuora/Object/InvoiceItem.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class InvoiceItem extends Object {
+class InvoiceItem extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/InvoiceItem.php
+++ b/src/Zuora/Object/InvoiceItem.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class InvoiceItem extends ZuoraObject {
+class InvoiceItem extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -108,5 +108,4 @@ class InvoiceItem extends ZuoraObject {
     {
         return $this->unitOfMeasure;
     }
-
-} 
+}

--- a/src/Zuora/Object/InvoiceSummary.php
+++ b/src/Zuora/Object/InvoiceSummary.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class InvoiceSummary extends ZuoraObject {
+class InvoiceSummary extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -60,4 +60,4 @@ class InvoiceSummary extends ZuoraObject {
     {
         return $this->status;
     }
-} 
+}

--- a/src/Zuora/Object/InvoiceSummary.php
+++ b/src/Zuora/Object/InvoiceSummary.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class InvoiceSummary extends Object {
+class InvoiceSummary extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/Payment.php
+++ b/src/Zuora/Object/Payment.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class Payment extends ZuoraObject {
+class Payment extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -101,5 +101,4 @@ class Payment extends ZuoraObject {
     {
         return $this->type;
     }
-
 }

--- a/src/Zuora/Object/Payment.php
+++ b/src/Zuora/Object/Payment.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class Payment extends Object {
+class Payment extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/PaymentSummary.php
+++ b/src/Zuora/Object/PaymentSummary.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class PaymentSummary extends ZuoraObject {
+class PaymentSummary extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -53,4 +53,4 @@ class PaymentSummary extends ZuoraObject {
     {
         return $this->status;
     }
-} 
+}

--- a/src/Zuora/Object/PaymentSummary.php
+++ b/src/Zuora/Object/PaymentSummary.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class PaymentSummary extends Object {
+class PaymentSummary extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/Product.php
+++ b/src/Zuora/Object/Product.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class Product extends Object {
+class Product extends ZuoraObject {
 
     public function getId()
     {

--- a/src/Zuora/Object/Product.php
+++ b/src/Zuora/Object/Product.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class Product extends ZuoraObject {
+class Product extends ZuoraObject
+{
 
     public function getId()
     {
@@ -26,10 +26,10 @@ class Product extends ZuoraObject {
     }
 
     /**
-     * @return ProductRatePlan[]
+     * @return \Zuora\Object\ProductRatePlan[]
      */
     public function getRatePlans()
     {
-        return $this->map('productRatePlans', '\Zuora\Object\ProductRatePlan');
+        return $this->map('productRatePlans', ProductRatePlan::class);
     }
-} 
+}

--- a/src/Zuora/Object/ProductRatePlan.php
+++ b/src/Zuora/Object/ProductRatePlan.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class ProductRatePlan extends ZuoraObject {
+class ProductRatePlan extends ZuoraObject
+{
 
     /**
      * Zuora id
@@ -73,6 +73,6 @@ class ProductRatePlan extends ZuoraObject {
      */
     public function getRatePlanCharges()
     {
-        return $this->map('productRatePlanCharges', '\Zuora\Object\ProductRatePlanCharge');
+        return $this->map('productRatePlanCharges', ProductRatePlanCharge::class);
     }
-} 
+}

--- a/src/Zuora/Object/ProductRatePlan.php
+++ b/src/Zuora/Object/ProductRatePlan.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class ProductRatePlan extends Object {
+class ProductRatePlan extends ZuoraObject {
 
     /**
      * Zuora id

--- a/src/Zuora/Object/ProductRatePlanCharge.php
+++ b/src/Zuora/Object/ProductRatePlanCharge.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class ProductRatePlanCharge extends Object {
+class ProductRatePlanCharge extends ZuoraObject {
 
     /**
      * Zuora id

--- a/src/Zuora/Object/ProductRatePlanCharge.php
+++ b/src/Zuora/Object/ProductRatePlanCharge.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class ProductRatePlanCharge extends ZuoraObject {
+class ProductRatePlanCharge extends ZuoraObject
+{
 
     /**
      * Zuora id
@@ -118,5 +118,4 @@ class ProductRatePlanCharge extends ZuoraObject {
     {
         return $this->taxable;
     }
-
-} 
+}

--- a/src/Zuora/Object/Reason.php
+++ b/src/Zuora/Object/Reason.php
@@ -1,15 +1,9 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: mhrabovcin
- * Date: 10/05/14
- * Time: 19:36
- */
 
 namespace Zuora\Object;
 
-
-class Reason extends ZuoraObject {
+class Reason extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -26,5 +20,4 @@ class Reason extends ZuoraObject {
     {
         return $this->message;
     }
-
-} 
+}

--- a/src/Zuora/Object/Reason.php
+++ b/src/Zuora/Object/Reason.php
@@ -9,7 +9,7 @@
 namespace Zuora\Object;
 
 
-class Reason extends Object {
+class Reason extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/Subscription.php
+++ b/src/Zuora/Object/Subscription.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class Subscription extends Object {
+class Subscription extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/Subscription.php
+++ b/src/Zuora/Object/Subscription.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class Subscription extends ZuoraObject {
+class Subscription extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -158,4 +158,4 @@ class Subscription extends ZuoraObject {
     {
         return $this->totalContractedValue;
     }
-} 
+}

--- a/src/Zuora/Object/SubscriptionRatePlan.php
+++ b/src/Zuora/Object/SubscriptionRatePlan.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class SubscriptionRatePlan extends Object {
+class SubscriptionRatePlan extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/SubscriptionRatePlan.php
+++ b/src/Zuora/Object/SubscriptionRatePlan.php
@@ -2,15 +2,15 @@
 
 namespace Zuora\Object;
 
-
-class SubscriptionRatePlan extends ZuoraObject {
+class SubscriptionRatePlan extends ZuoraObject
+{
 
     /**
      * @return mixed
      */
     public function getLastChangeType()
     {
-      return $this->lastChangeType;
+        return $this->lastChangeType;
     }
 
     /**
@@ -18,7 +18,7 @@ class SubscriptionRatePlan extends ZuoraObject {
      */
     public function getProductId()
     {
-      return $this->productId;
+        return $this->productId;
     }
 
     /**
@@ -26,7 +26,7 @@ class SubscriptionRatePlan extends ZuoraObject {
      */
     public function getProductRatePlanId()
     {
-      return $this->productRatePlanId;
+        return $this->productRatePlanId;
     }
 
     /**
@@ -62,5 +62,4 @@ class SubscriptionRatePlan extends ZuoraObject {
     {
         return $this->ratePlanName;
     }
-
-} 
+}

--- a/src/Zuora/Object/SubscriptionRatePlanCharge.php
+++ b/src/Zuora/Object/SubscriptionRatePlanCharge.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class SubscriptionRatePlanCharge extends ZuoraObject {
+class SubscriptionRatePlanCharge extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -68,5 +68,4 @@ class SubscriptionRatePlanCharge extends ZuoraObject {
     {
         return $this->type;
     }
-
-} 
+}

--- a/src/Zuora/Object/SubscriptionRatePlanCharge.php
+++ b/src/Zuora/Object/SubscriptionRatePlanCharge.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class SubscriptionRatePlanCharge extends Object {
+class SubscriptionRatePlanCharge extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/SubscriptionSummary.php
+++ b/src/Zuora/Object/SubscriptionSummary.php
@@ -2,7 +2,6 @@
 
 namespace Zuora\Object;
 
-
 class SubscriptionSummary extends ZuoraObject
 {
 
@@ -93,4 +92,4 @@ class SubscriptionSummary extends ZuoraObject
     {
         return $this->termType;
     }
-} 
+}

--- a/src/Zuora/Object/SubscriptionSummary.php
+++ b/src/Zuora/Object/SubscriptionSummary.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class SubscriptionSummary extends Object
+class SubscriptionSummary extends ZuoraObject
 {
 
     /**

--- a/src/Zuora/Object/Usage.php
+++ b/src/Zuora/Object/Usage.php
@@ -1,11 +1,9 @@
 <?php
 
-
 namespace Zuora\Object;
 
-
-class Usage extends ZuoraObject {
-
+class Usage extends ZuoraObject
+{
     /**
      * @return mixed
      */
@@ -101,5 +99,4 @@ class Usage extends ZuoraObject {
     {
         return $this->unitOfMeasure;
     }
-
-} 
+}

--- a/src/Zuora/Object/Usage.php
+++ b/src/Zuora/Object/Usage.php
@@ -4,7 +4,7 @@
 namespace Zuora\Object;
 
 
-class Usage extends Object {
+class Usage extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/UsageSummary.php
+++ b/src/Zuora/Object/UsageSummary.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class UsageSummary extends Object {
+class UsageSummary extends ZuoraObject {
 
     /**
      * @return mixed

--- a/src/Zuora/Object/UsageSummary.php
+++ b/src/Zuora/Object/UsageSummary.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class UsageSummary extends ZuoraObject {
+class UsageSummary extends ZuoraObject
+{
 
     /**
      * @return mixed
@@ -28,5 +28,4 @@ class UsageSummary extends ZuoraObject {
     {
         return $this->unitOfMeasure;
     }
-
-} 
+}

--- a/src/Zuora/Object/UsageUploadResult.php
+++ b/src/Zuora/Object/UsageUploadResult.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class UsageUploadResult extends Object {
+class UsageUploadResult extends ZuoraObject {
 
     /**
      * Retrieve uploaded file size

--- a/src/Zuora/Object/UsageUploadResult.php
+++ b/src/Zuora/Object/UsageUploadResult.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class UsageUploadResult extends ZuoraObject {
+class UsageUploadResult extends ZuoraObject
+{
 
     /**
      * Retrieve uploaded file size
@@ -34,6 +34,6 @@ class UsageUploadResult extends ZuoraObject {
     public function getImportStatusId()
     {
         preg_match('~usage/(?<id>[^/]+)/status~i', $this->getImportStatusUrl(), $match);
-        return isset($match['id']) ? $match['id'] : NULL;
+        return isset($match['id']) ? $match['id'] : null;
     }
-} 
+}

--- a/src/Zuora/Object/ZuoraObject.php
+++ b/src/Zuora/Object/ZuoraObject.php
@@ -3,7 +3,7 @@
 namespace Zuora\Object;
 
 
-class Object {
+class ZuoraObject {
 
 
     /**

--- a/src/Zuora/Object/ZuoraObject.php
+++ b/src/Zuora/Object/ZuoraObject.php
@@ -2,9 +2,8 @@
 
 namespace Zuora\Object;
 
-
-class ZuoraObject {
-
+class ZuoraObject
+{
 
     /**
      * Data retrieved from API response
@@ -18,7 +17,7 @@ class ZuoraObject {
      *
      * @var array
      */
-    protected $mapped = array();
+    protected $mapped = [];
 
 
     /**
@@ -26,7 +25,7 @@ class ZuoraObject {
      *
      * @param array $data
      */
-    function __construct($data = array())
+    public function __construct($data = [])
     {
         $this->data = $data;
     }
@@ -38,7 +37,7 @@ class ZuoraObject {
      *
      * @return mixed
      */
-    function __get($name)
+    public function __get($name)
     {
         return isset($this->data[$name]) ? $this->data[$name] : null;
     }
@@ -81,7 +80,7 @@ class ZuoraObject {
     public function map($property, $classname)
     {
         if (!isset($this->mapped[$property])) {
-            $this->mapped[$property] = array();
+            $this->mapped[$property] = [];
 
             if (!isset($this->data[$property])) {
                 throw new \InvalidArgumentException("{$property} doesn't exists.");
@@ -95,7 +94,7 @@ class ZuoraObject {
                 throw new \InvalidArgumentException("{$classname} isn't valid name of PHP class.");
             }
 
-            $objects = array();
+            $objects = [];
 
             foreach ($this->data[$property] as $record) {
                 $objects[] = new $classname($record);

--- a/src/Zuora/Response.php
+++ b/src/Zuora/Response.php
@@ -2,6 +2,7 @@
 
 namespace Zuora;
 
+use Zuora\Object\ZuoraObject;
 
 class Response
 {
@@ -15,7 +16,6 @@ class Response
      */
     protected $client;
 
-
     /**
      * Constructor
      *
@@ -25,7 +25,7 @@ class Response
      * @param \Zuora\Client $client
      *   Initialized client class
      */
-    function __construct(\Zuora\Http\Response $response, \Zuora\Client $client)
+    public function __construct(\Zuora\Http\Response $response, Client $client)
     {
         $this->response = $response;
         $this->client = $client;
@@ -56,16 +56,20 @@ class Response
     public function map($entity, $classname)
     {
         $data = $this->response->getData();
-        $object = new \Zuora\Object\ZuoraObject($data);
+        $object = new ZuoraObject($data);
         return $object->map($entity, $classname);
     }
 
     /**
      * For paged response fetch next result
      *
-     * @return \Zuora\Response
+     * @return \Zuora\Response|null
+     *
+     * @throws \Zuora\Exception\ApiException
+     * @throws \Zuora\Exception\ResponseException
      */
-    public function nextPage() {
+    public function nextPage()
+    {
 
         $data = $this->response->getData();
 
@@ -81,4 +85,4 @@ class Response
 
         return null;
     }
-} 
+}

--- a/src/Zuora/Response.php
+++ b/src/Zuora/Response.php
@@ -56,7 +56,7 @@ class Response
     public function map($entity, $classname)
     {
         $data = $this->response->getData();
-        $object = new \Zuora\Object\Object($data);
+        $object = new \Zuora\Object\ZuoraObject($data);
         return $object->map($entity, $classname);
     }
 

--- a/test/Zuora/Test/Base.php
+++ b/test/Zuora/Test/Base.php
@@ -15,15 +15,14 @@ class Base extends TestCase
      *
      * @return \Zuora\Environment
      */
-    protected function getEnvironment($options = array())
+    protected function getEnvironment($options = [])
     {
-        return \Zuora\Environment::factory($options + array(
+        return \Zuora\Environment::factory($options + [
            'username' => 'first.last@example.com',
            'password' => 'password',
            'endpoint' => 'http://api.example.com/rest',
-        ));
+        ]);
     }
-
 
     /**
      * Call protected/private method of a class.
@@ -37,7 +36,7 @@ class Base extends TestCase
      *
      * @return mixed Method return.
      */
-    public function invokeMethod($object, $methodName, array $parameters = array())
+    public function invokeMethod($object, $methodName, array $parameters = [])
     {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);
@@ -45,5 +44,4 @@ class Base extends TestCase
 
         return $method->invokeArgs($object, $parameters);
     }
-
-} 
+}

--- a/test/Zuora/Test/Base.php
+++ b/test/Zuora/Test/Base.php
@@ -2,8 +2,10 @@
 
 namespace Zuora\Test;
 
+use PHPUnit\Framework\TestCase;
 
-class Base extends \PHPUnit_Framework_TestCase {
+class Base extends TestCase
+{
 
     /**
      * Get test environment

--- a/test/Zuora/Test/ClientTest.php
+++ b/test/Zuora/Test/ClientTest.php
@@ -2,8 +2,8 @@
 
 namespace Zuora\Test;
 
-
 use Zuora\Client;
+use Zuora\Http\RequestInterface;
 use Zuora\Http\Response;
 
 class ClientTest extends \Zuora\Test\Base {
@@ -17,18 +17,18 @@ class ClientTest extends \Zuora\Test\Base {
     public function testClientErrorCurlResponse()
     {
 
-        $enviroment = $this->getEnvironment();
+        $environment = $this->getEnvironment();
         $error_response = new Response();
         $error_response->setCode(0)
             ->setErrorCode(68)
             ->setErrorMessage("connection to host timed out");
 
-        $request = $this->getMock('\Zuora\Http\RequestInterface');
+        $request = $this->createMock(RequestInterface::class);
         $request->expects($this->once())
             ->method('call')
             ->will($this->returnValue($error_response));
 
-        $client = new Client($enviroment, $request);
+        $client = new Client($environment, $request);
         $client->request('test');
     }
 
@@ -38,16 +38,16 @@ class ClientTest extends \Zuora\Test\Base {
      * @expectedException \Zuora\Exception\ResponseException
      */
     public function testClientApiErrorResponse() {
-        $enviroment = $this->getEnvironment();
+        $environment = $this->getEnvironment();
         $error_response = new Response();
         $error_response->setCode(400);
 
-        $request = $this->getMock('\Zuora\Http\RequestInterface');
+        $request = $this->createMock(RequestInterface::class);
         $request->expects($this->once())
            ->method('call')
            ->will($this->returnValue($error_response));
 
-        $client = new Client($enviroment, $request);
+        $client = new Client($environment, $request);
         $client->request('test');
     }
 
@@ -58,7 +58,7 @@ class ClientTest extends \Zuora\Test\Base {
      */
     public function testClientLogicErrorResponse()
     {
-        $enviroment = $this->getEnvironment();
+        $environment = $this->getEnvironment();
         $error_response = new Response();
         $error_response->setCode(200)
             ->setData(array(
@@ -70,12 +70,12 @@ class ClientTest extends \Zuora\Test\Base {
                )
             ));
 
-        $request = $this->getMock('\Zuora\Http\RequestInterface');
+        $request = $this->createMock(RequestInterface::class);
         $request->expects($this->once())
            ->method('call')
            ->will($this->returnValue($error_response));
 
-        $client = new Client($enviroment, $request);
+        $client = new Client($environment, $request);
         $client->request('test');
 
     }

--- a/test/Zuora/Test/ClientTest.php
+++ b/test/Zuora/Test/ClientTest.php
@@ -6,8 +6,8 @@ use Zuora\Client;
 use Zuora\Http\RequestInterface;
 use Zuora\Http\Response;
 
-class ClientTest extends \Zuora\Test\Base {
-
+class ClientTest extends Base
+{
 
     /**
      * Test cURL error
@@ -37,7 +37,8 @@ class ClientTest extends \Zuora\Test\Base {
      *
      * @expectedException \Zuora\Exception\ResponseException
      */
-    public function testClientApiErrorResponse() {
+    public function testClientApiErrorResponse()
+    {
         $environment = $this->getEnvironment();
         $error_response = new Response();
         $error_response->setCode(400);
@@ -61,14 +62,14 @@ class ClientTest extends \Zuora\Test\Base {
         $environment = $this->getEnvironment();
         $error_response = new Response();
         $error_response->setCode(200)
-            ->setData(array(
+            ->setData([
                'success' => false,
                'processId' => '3F7EA3FD706C7E7C',
-               'reasons' => array(
-                  array('code' => 53100020, 'message' => ' {com.zuora.constraints.either_or_both}',),
-                  array('code' => 53100320, 'message' => "'termType' value should be one of: TERMED, EVERGREEN",)
-               )
-            ));
+               'reasons' => [
+                  ['code' => 53100020, 'message' => ' {com.zuora.constraints.either_or_both}',],
+                  ['code' => 53100320, 'message' => "'termType' value should be one of: TERMED, EVERGREEN",]
+               ]
+            ]);
 
         $request = $this->createMock(RequestInterface::class);
         $request->expects($this->once())
@@ -77,6 +78,5 @@ class ClientTest extends \Zuora\Test\Base {
 
         $client = new Client($environment, $request);
         $client->request('test');
-
     }
-} 
+}

--- a/test/Zuora/Test/EnvironmentTest.php
+++ b/test/Zuora/Test/EnvironmentTest.php
@@ -9,12 +9,12 @@ class EnvironmentTest extends TestCase
 {
     public function testFactory()
     {
-        $options = array(
+        $options = [
             'username' => 'email@example.com',
             'password' => 'secretpassword',
             'endpoint' => 'https://endpoint.com/rest',
             'version' => '2',
-        );
+        ];
 
         $env = Environment::factory($options);
 
@@ -24,4 +24,4 @@ class EnvironmentTest extends TestCase
         $this->assertEquals($options['version'], $env->getVersion());
         $this->assertEquals('https://endpoint.com/rest/v2/test', $env->getUrl('test'));
     }
-} 
+}

--- a/test/Zuora/Test/EnvironmentTest.php
+++ b/test/Zuora/Test/EnvironmentTest.php
@@ -2,9 +2,10 @@
 
 namespace Zuora\Test;
 
+use PHPUnit\Framework\TestCase;
 use Zuora\Environment;
 
-class EnvironmentTest extends \PHPUnit_Framework_TestCase
+class EnvironmentTest extends TestCase
 {
     public function testFactory()
     {

--- a/test/Zuora/Test/Exception/ApiExceptionTest.php
+++ b/test/Zuora/Test/Exception/ApiExceptionTest.php
@@ -2,11 +2,12 @@
 
 namespace Zuora\Test\Exception;
 
-
+use PHPUnit\Framework\TestCase;
 use Zuora\Exception\ApiException;
 use Zuora\Http\Response;
 
-class ApiExceptionTest extends \PHPUnit_Framework_TestCase {
+class ApiExceptionTest extends TestCase
+{
 
     protected $error_data = '{
   "success": false,

--- a/test/Zuora/Test/Exception/ApiExceptionTest.php
+++ b/test/Zuora/Test/Exception/ApiExceptionTest.php
@@ -36,7 +36,7 @@ class ApiExceptionTest extends TestCase
         $this->assertCount(2, $exception->getReasons());
 
         foreach ($exception->getReasons() as $reason) {
-            $this->assertTrue(in_array($reason->getCode(), array(53100020, 53100320)));
+            $this->assertTrue(in_array($reason->getCode(), [53100020, 53100320]));
         }
 
         $string = $exception->__toString();
@@ -47,5 +47,4 @@ class ApiExceptionTest extends TestCase
             $this->assertContains($reason->getMessage(), $string);
         }
     }
-
-} 
+}

--- a/test/Zuora/Test/Exception/ResponseExceptionTest.php
+++ b/test/Zuora/Test/Exception/ResponseExceptionTest.php
@@ -2,10 +2,12 @@
 
 namespace Zuora\Test\Exception;
 
+use PHPUnit\Framework\TestCase;
 use Zuora\Exception\ResponseException;
 use Zuora\Http\Response;
 
-class ResponseExceptionTest extends \PHPUnit_Framework_TestCase {
+class ResponseExceptionTest extends TestCase
+{
 
     public function testResponseException()
     {

--- a/test/Zuora/Test/Exception/ResponseExceptionTest.php
+++ b/test/Zuora/Test/Exception/ResponseExceptionTest.php
@@ -35,4 +35,4 @@ class ResponseExceptionTest extends TestCase
 
         $this->assertContains($response->getErrorMessage(), $exception->getMessageFromResponse());
     }
-} 
+}

--- a/test/Zuora/Test/Http/RequestTest.php
+++ b/test/Zuora/Test/Http/RequestTest.php
@@ -2,32 +2,32 @@
 
 namespace Zuora\Test\Http;
 
-
 use Zuora\Http\Request;
 
-class RequestTest extends \Zuora\Test\Base {
+class RequestTest extends \Zuora\Test\Base
+{
 
     public function testRequestUrlHelpers()
     {
         $request = new Request();
-        $this->assertEquals($this->invokeMethod($request, 'normalizeHttpMethod', array('get')), 'GET');
+        $this->assertEquals($this->invokeMethod($request, 'normalizeHttpMethod', ['get']), 'GET');
 
-        $result = $this->invokeMethod($request, 'normalizeUrl', array('http://www.example.com'));
+        $result = $this->invokeMethod($request, 'normalizeUrl', ['http://www.example.com']);
         $this->assertEquals($result[0], 'http://www.example.com');
         $this->assertEquals($result[1], null);
 
         // Test url with port
-        $result = $this->invokeMethod($request, 'normalizeUrl', array('http://www.example.com:8080/index?q=1'));
+        $result = $this->invokeMethod($request, 'normalizeUrl', ['http://www.example.com:8080/index?q=1']);
         $this->assertEquals($result[0], 'http://www.example.com/index?q=1');
         $this->assertEquals($result[1], 8080);
 
         // Test url with provided query
-        $result = $this->invokeMethod($request, 'normalizeUrl', array('http://www.example.com/index', array('q' => 1)));
+        $result = $this->invokeMethod($request, 'normalizeUrl', ['http://www.example.com/index', ['q' => 1]]);
         $this->assertEquals($result[0], 'http://www.example.com/index?q=1');
         $this->assertEquals($result[1], null);
 
         // Test query merging
-        $result = $this->invokeMethod($request, 'normalizeUrl', array('http://www.example.com/index?a=1', array('q' => 1)));
+        $result = $this->invokeMethod($request, 'normalizeUrl', ['http://www.example.com/index?a=1', ['q' => 1]]);
         $this->assertEquals($result[0], 'http://www.example.com/index?a=1&q=1');
         $this->assertEquals($result[1], null);
     }
@@ -37,52 +37,50 @@ class RequestTest extends \Zuora\Test\Base {
 
         $url = 'http://www.example.com';
         $port = null;
-        $method = 'GET';
-        $data = array('data' => 'test');
-        $headers = array('X-Custom' => 'value');
-        $files = array('file' => '@/path/to/file');
+        $data = ['data' => 'test'];
+        $headers = ['X-Custom' => 'value'];
+        $files = ['file' => '@/path/to/file'];
 
         $request = new Request();
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url));
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url]);
         $this->assertEquals($options[CURLOPT_URL], $url);
 
         $port = 8000;
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url, $port));
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url, $port]);
         $this->assertEquals($options[CURLOPT_PORT], $port);
 
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url, $port, 'POST'));
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url, $port, 'POST']);
         $this->assertEquals($options[CURLOPT_POST], 1);
 
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url, $port, 'PUT'));
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url, $port, 'PUT']);
         $this->assertEquals($options[CURLOPT_CUSTOMREQUEST], 'PUT');
 
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url, $port, 'DELETE'));
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url, $port, 'DELETE']);
         $this->assertEquals($options[CURLOPT_CUSTOMREQUEST], 'DELETE');
 
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url, $port, 'GET', $data));
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url, $port, 'GET', $data]);
         $this->assertTrue(!isset($options[CURLOPT_POSTFIELDS]));
 
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url, $port, 'POST', $data));
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url, $port, 'POST', $data]);
         $this->assertNotEmpty($options[CURLOPT_POSTFIELDS]);
         $this->assertContains('test', $options[CURLOPT_POSTFIELDS]);
 
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url, $port, 'POST', $data, $headers));
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url, $port, 'POST', $data, $headers]);
         $this->assertEquals($options[CURLOPT_HTTPHEADER][0], 'X-Custom: value');
 
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url, $port, 'POST', $data, $headers, $files));
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url, $port, 'POST', $data, $headers, $files]);
         $this->assertInternalType('array', $options[CURLOPT_POSTFIELDS]);
 
         // Test custom curl options
-        $request = new Request(array(
+        $request = new Request([
             'timeout' => 10,
             'ssl_verifypeer_skip' => true,
-            'user_agent' => 'test'
-        ));
-        $options = $this->invokeMethod($request, 'getCurlOptions', array($url, $port, 'POST', $data));
+            'user_agent' => 'test',
+        ]);
+        $options = $this->invokeMethod($request, 'getCurlOptions', [$url, $port, 'POST', $data]);
         $this->assertEquals($options[CURLOPT_TIMEOUT], 10);
         $this->assertEquals($options[CURLOPT_USERAGENT], 'test');
         $this->assertEquals($options[CURLOPT_SSL_VERIFYHOST], false);
         $this->assertEquals($options[CURLOPT_SSL_VERIFYPEER], false);
     }
-
-} 
+}

--- a/test/Zuora/Test/Http/ResponseTest.php
+++ b/test/Zuora/Test/Http/ResponseTest.php
@@ -37,7 +37,7 @@ class ResponseTest extends TestCase
         $response = Response::fromString($this->getTestOkResponse());
         $this->assertEquals($response->getCode(), 200);
         $this->assertEquals($response->getData(), '{"success": true}');
-        $this->assertEquals($response->getCookies(), array());
+        $this->assertEquals($response->getCookies(), []);
     }
 
     public function testCookieParser()
@@ -67,4 +67,4 @@ class ResponseTest extends TestCase
         $response->setErrorCode(68);
         $this->assertTrue($response->isError());
     }
-} 
+}

--- a/test/Zuora/Test/Http/ResponseTest.php
+++ b/test/Zuora/Test/Http/ResponseTest.php
@@ -2,9 +2,11 @@
 
 namespace Zuora\Test\Http;
 
+use PHPUnit\Framework\TestCase;
 use Zuora\Http\Response;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase {
+class ResponseTest extends TestCase
+{
 
     protected function getTestOkResponse()
     {

--- a/test/Zuora/Test/Object/ZuoraObjectTest.php
+++ b/test/Zuora/Test/Object/ZuoraObjectTest.php
@@ -10,11 +10,11 @@ class ZuoraObjectTest extends TestCase
 
     public function testObject()
     {
-        $data = array(
+        $data = [
             'id' => md5(rand()),
             'name' => 'testname',
             'CustomField__c' => 'value',
-        );
+        ];
 
         $object = new ZuoraObject($data);
         $this->assertEquals($object->id, $data['id']);
@@ -30,7 +30,7 @@ class ZuoraObjectTest extends TestCase
      */
     public function testMapWrongArgument()
     {
-        $data = array();
+        $data = [];
         $object = new ZuoraObject($data);
         $object->map('noexisting', '\Zuora\Object\ZuoraObject');
     }
@@ -42,7 +42,7 @@ class ZuoraObjectTest extends TestCase
      */
     public function testdMapWrongArgumentType()
     {
-        $data = array('scalar' => 'value');
+        $data = ['scalar' => 'value'];
         $object = new ZuoraObject($data);
         $object->map('scalar', '\Zuora\Object\ZuoraObject');
     }
@@ -54,8 +54,8 @@ class ZuoraObjectTest extends TestCase
      */
     public function testdMapWrongClassname()
     {
-        $data = array('test' => array());
+        $data = ['test' => []];
         $object = new ZuoraObject($data);
         $object->map('test', 'MissingClass');
     }
-} 
+}

--- a/test/Zuora/Test/Object/ZuoraObjectTest.php
+++ b/test/Zuora/Test/Object/ZuoraObjectTest.php
@@ -3,9 +3,9 @@
 namespace Zuora\Test\Object;
 
 
-use Zuora\Object\Object;
+use Zuora\Object\ZuoraObject;
 
-class ObjectTest extends \PHPUnit_Framework_TestCase {
+class ZuoraObjectTest extends \PHPUnit_Framework_TestCase {
 
     public function testObject()
     {
@@ -15,7 +15,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase {
             'CustomField__c' => 'value',
         );
 
-        $object = new Object($data);
+        $object = new ZuoraObject($data);
         $this->assertEquals($object->id, $data['id']);
         $this->assertEquals($object->name, $data['name']);
         $this->assertEquals($object->getCustomField('CustomField'), $data['CustomField__c']);
@@ -30,8 +30,8 @@ class ObjectTest extends \PHPUnit_Framework_TestCase {
     public function testMapWrongArgument()
     {
         $data = array();
-        $object = new Object($data);
-        $object->map('noexisting', '\Zuora\Object\Object');
+        $object = new ZuoraObject($data);
+        $object->map('noexisting', '\Zuora\Object\ZuoraObject');
     }
 
     /**
@@ -42,8 +42,8 @@ class ObjectTest extends \PHPUnit_Framework_TestCase {
     public function testdMapWrongArgumentType()
     {
         $data = array('scalar' => 'value');
-        $object = new Object($data);
-        $object->map('scalar', '\Zuora\Object\Object');
+        $object = new ZuoraObject($data);
+        $object->map('scalar', '\Zuora\Object\ZuoraObject');
     }
 
     /**
@@ -54,7 +54,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase {
     public function testdMapWrongClassname()
     {
         $data = array('test' => array());
-        $object = new Object($data);
+        $object = new ZuoraObject($data);
         $object->map('test', 'MissingClass');
     }
 } 

--- a/test/Zuora/Test/Object/ZuoraObjectTest.php
+++ b/test/Zuora/Test/Object/ZuoraObjectTest.php
@@ -2,10 +2,11 @@
 
 namespace Zuora\Test\Object;
 
-
+use PHPUnit\Framework\TestCase;
 use Zuora\Object\ZuoraObject;
 
-class ZuoraObjectTest extends \PHPUnit_Framework_TestCase {
+class ZuoraObjectTest extends TestCase
+{
 
     public function testObject()
     {

--- a/test/Zuora/Test/ResponseTest.php
+++ b/test/Zuora/Test/ResponseTest.php
@@ -6,7 +6,8 @@ use Zuora\Client;
 use Zuora\Http\RequestInterface;
 use Zuora\Http\Response;
 
-class ResponseTest extends Base {
+class ResponseTest extends Base
+{
 
     /**
      * Tests Response pagination and class mapping
@@ -15,38 +16,39 @@ class ResponseTest extends Base {
     {
         $environment = $this->getEnvironment();
 
-        $response_data = array(
-           'success' => true,
-           'creditCards' => array(
-              array('id' => md5(rand())),
-           ),
-           'nextPage' => $environment->getUrl('accounts') . '?page=2',
-        );
+        $response_data = [
+            'success' => true,
+            'creditCards' => [
+                ['id' => md5(rand())],
+            ],
+            'nextPage' => $environment->getUrl('accounts') . '?page=2',
+        ];
 
         $http_response = new Response();
         $http_response->setData($response_data)
             ->setCode(200)
-            ->setHeaders(array());
+            ->setHeaders([]);
 
         $next_response = new Response();
         $next_response->setCode(200)
-            ->setHeaders(array())
-            ->setData(array('nextPage' => $environment->getUrl('accounts') . '?page=3') + $response_data);
+            ->setHeaders([])
+            ->setData(['nextPage' => $environment->getUrl('accounts') . '?page=3'] + $response_data);
 
 
         $request = $this->createMock(RequestInterface::class);
         $request->expects($this->once())
-           ->method('call')
-           ->with($this->equalTo($environment->getUrl('accounts')),
-                  $this->equalTo('GET'),
-                  $this->equalTo(array('page' => 2)),
-                  $this->anything(),
-                  $this->equalTo(array(
-                     'apiAccessKeyId' => $environment->getUsername(),
-                     'apiSecretAccessKey' => $environment->getPassword(),
-                  ))
-           )
-           ->will($this->returnValue($next_response));
+            ->method('call')
+            ->with(
+                $this->equalTo($environment->getUrl('accounts')),
+                $this->equalTo('GET'),
+                $this->equalTo(['page' => 2]),
+                $this->anything(),
+                $this->equalTo([
+                    'apiAccessKeyId' => $environment->getUsername(),
+                    'apiSecretAccessKey' => $environment->getPassword(),
+                ])
+            )
+            ->will($this->returnValue($next_response));
 
         $client = new Client($environment, $request);
 
@@ -58,8 +60,7 @@ class ResponseTest extends Base {
         $cards = $response->map('creditCards', '\Zuora\Object\CreditCard');
         $this->assertInternalType('array', $cards);
 
-        $response = new \Zuora\Response($http_response->setData(array()), $client);
+        $response = new \Zuora\Response($http_response->setData([]), $client);
         $this->assertNull($response->nextPage());
     }
-
-} 
+}

--- a/test/Zuora/Test/ResponseTest.php
+++ b/test/Zuora/Test/ResponseTest.php
@@ -2,12 +2,11 @@
 
 namespace Zuora\Test;
 
-
 use Zuora\Client;
-use Zuora\Environment;
+use Zuora\Http\RequestInterface;
 use Zuora\Http\Response;
 
-class ResponseTest extends \Zuora\Test\Base {
+class ResponseTest extends Base {
 
     /**
      * Tests Response pagination and class mapping
@@ -35,7 +34,7 @@ class ResponseTest extends \Zuora\Test\Base {
             ->setData(array('nextPage' => $environment->getUrl('accounts') . '?page=3') + $response_data);
 
 
-        $request = $this->getMock('\Zuora\Http\RequestInterface');
+        $request = $this->createMock(RequestInterface::class);
         $request->expects($this->once())
            ->method('call')
            ->with($this->equalTo($environment->getUrl('accounts')),


### PR DESCRIPTION
- [x] Renamed Object into ZuoraObject in order to support PHP 7.2
- [x] updated phpunit to 7.5
- [x] minimum supported PHP version bumped to ^7.1
- [x] fixed php-coveralls
- [x] php matrix in travis now 7.1, 7.2 & 73
- [x] fix issues identified by `phpcs --standard=PSR2 ./src/`